### PR TITLE
Remove ruby gem deps

### DIFF
--- a/2.3.0/Dockerfile
+++ b/2.3.0/Dockerfile
@@ -8,17 +8,17 @@ ENV DEBIAN_FRONTEND noninteractive
 # --no-install-recommends to avoid installing fuse (unsupported in docker < 1.0)
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get install --no-install-recommends -y wget build-essential ca-certificates libmysqlclient-dev libpq-dev libsqlite3-dev autoconf bison libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev && \
+    apt-get install --no-install-recommends -y wget build-essential ca-certificates autoconf bison libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev && \
     apt-get autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN mkdir ruby-build && \
-    wget -qO- https://github.com/rbenv/ruby-build/archive/v20160111.tar.gz | \ 
+    wget -qO- https://github.com/rbenv/ruby-build/archive/v20160111.tar.gz | \
     tar xz -C ruby-build/ --strip-components 1 && \
     cd ruby-build && \
     ./bin/ruby-build 2.3.0 /usr/local && rm -rf ruby-build
-    
+
 RUN gem install bundler 
 
 WORKDIR /rails_app

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -14,7 +14,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN mkdir ruby-build && \
-    wget -qO- https://github.com/rbenv/ruby-build//archive/<%= ruby_build %>.tar.gz | \
+    wget -qO- https://github.com/rbenv/ruby-build/archive/<%= ruby_build %>.tar.gz | \
     tar xz -C ruby-build/ --strip-components 1 && \
     cd ruby-build && \
     ./bin/ruby-build <%= ruby %> /usr/local && rm -rf ruby-build

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -14,11 +14,11 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN mkdir ruby-build && \
-    wget -qO- https://github.com/sstephenson/ruby-build/archive/<%= ruby_build %>.tar.gz | \ 
+    wget -qO- https://github.com/rbenv/ruby-build//archive/<%= ruby_build %>.tar.gz | \
     tar xz -C ruby-build/ --strip-components 1 && \
     cd ruby-build && \
     ./bin/ruby-build <%= ruby %> /usr/local && rm -rf ruby-build
-    
+
 RUN gem install bundler <%= gems %>
 
 WORKDIR /rails_app

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Docker Containers are automatically build from [zooniverse/ruby](https://hub.doc
 ## Usage
 
 We use [ruby-build](https://github.com/sstephenson/ruby-build) and
-should be able to compile any supported rubies from that probject. 
+should be able to compile any supported rubies from that probject.
 
 `rake create` compiles the Dockerfile.erb into a Dockerfile after
 prompting for the ruby version and any additional dependencies and
 moves it into a subfolder with the provided ruby version.
 
 `rake create ruby=version deps=list of deps` skips the configuration
-prompts and uses the supplied values. 
+prompts and uses the supplied values.
 
 `rake build hub_name=username` creates a new ruby as `rake create` and
 runs docker build on it prefixing the resulting image with the suppied
@@ -28,7 +28,7 @@ to Docker Hub.
 
 ## Autobuilds
 
-+ **MRI 2.1.2** - with mysql and postgres client libraries installed.
++ **MRI 2.3.0**
 
 + **JRuby 1.7.16** - running on OpenJDK 7.
 
@@ -37,4 +37,3 @@ to Docker Hub.
 Copyright 2014 by the Zooniverse
 
 Distributed under the Apache Public License v2. See LICENSE
-

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'yaml'
 
 task default: :create
 
-default_ruby_build_release = 'v20150303'
+default_ruby_build_release = 'v20160111'
 default_base_image = 'ubuntu:14.04'
 
 default_deps = %W(wget


### PR DESCRIPTION
Build a baseline image, all docker files that use this as a base image should specify the libs that the build requires, e.g. panoptes requires PG libs. 