### PR TITLE
Add Ruby 2.4.1

### DIFF
--- a/2.4.1/Dockerfile
+++ b/2.4.1/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:14.04
+
+ENV LANG en_US.UTF-8
+ENV CONFIGURE_OPTS --disable-install-rdoc 
+ENV JRUBY_OPTS --2.0
+ENV DEBIAN_FRONTEND noninteractive
+
+# --no-install-recommends to avoid installing fuse (unsupported in docker < 1.0)
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y wget build-essential ca-certificates autoconf bison libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev && \
+    apt-get autoremove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN mkdir ruby-build && \
+    wget -qO- https://github.com/rbenv/ruby-build/archive/v20160111.tar.gz | \
+    tar xz -C ruby-build/ --strip-components 1 && \
+    cd ruby-build && \
+    ./bin/ruby-build 2.4.1 /usr/local && rm -rf ruby-build
+
+RUN gem install bundler 
+
+WORKDIR /rails_app


### PR DESCRIPTION
Adds 2.4.1 to the list of available docker builds.